### PR TITLE
feature: CPA-709 dns management cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__
 
 # VS Code
 .vscode
+
+output.txt

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -7,7 +7,7 @@ import_heading_thirdparty=Third-Party Libraries
 import_heading_firstparty=cisagov Libraries
 
 # Should be auto-populated by seed-isort-config hook
-known_third_party=colorama,dotenv,pytest,requests,scripts,selenium,twocaptcha,utils
+known_third_party=colorama,dotenv,pytest,requests,scripts,selenium,setuptools,twocaptcha,utils
 # These must be manually set to correctly separate them from third party libraries
 known_first_party=
 

--- a/src/domain_manager/scripts/dns_record_handler.py
+++ b/src/domain_manager/scripts/dns_record_handler.py
@@ -1,0 +1,23 @@
+"""DNS record handler."""
+# Third-Party Libraries
+import requests
+from utils.message_handling import error_msg, success_msg
+from utils.settings import URL, auth
+
+
+def generate_hosted_zones():
+    """Generate Route53 Hosted Zones for specified domains."""
+    post_data = {
+        "domains": ["signalsquared.com", "signalcubed.com", "signalpowerthree.com"]
+    }
+    resp = requests.post(f"{URL}/api/generate-dns/", headers=auth, json=post_data)
+    try:
+        resp.raise_for_status()
+    except requests.exceptions.HTTPError as e:
+        error_msg(str(e))
+        return
+
+    success_msg(
+        "DNS handlers have been created for \n" + "\n".join(i for i in resp.json())
+    )
+    return resp.json()

--- a/src/domain_manager/scripts/dns_record_handler.py
+++ b/src/domain_manager/scripts/dns_record_handler.py
@@ -7,9 +7,12 @@ from utils.settings import URL, auth
 
 def generate_hosted_zones():
     """Generate Route53 Hosted Zones for specified domains."""
-    post_data = {
-        "domains": ["signalsquared.com", "signalcubed.com", "signalpowerthree.com"]
-    }
+    text_file_name = input("Please your txt file name: ")
+
+    post_data = {}
+    with open(f"text_files/{text_file_name}.txt", "r") as reader:
+        post_data["domains"] = [line.replace("\n", "") for line in reader]
+
     resp = requests.post(f"{URL}/api/generate-dns/", headers=auth, json=post_data)
     try:
         resp.raise_for_status()
@@ -17,7 +20,14 @@ def generate_hosted_zones():
         error_msg(str(e))
         return
 
-    success_msg(
-        "DNS handlers have been created for \n" + "\n".join(i for i in resp.json())
+    resp_txt = "\n\n".join(
+        key + "\n\n" + "\n".join(value) for key, value in resp.json().items()
     )
+    with open("output.txt", "w") as output:
+        output.write(resp_txt)
+
+    success_msg(
+        "DNS handlers have been created for: \n" + "\n".join(i for i in resp.json())
+    )
+    success_msg("\nPlease check output.txt to retrieve your nameservers")
     return resp.json()

--- a/src/domain_manager/scripts/run.py
+++ b/src/domain_manager/scripts/run.py
@@ -7,6 +7,7 @@ from colorama import Fore
 from scripts.active_sites import delete_live_site, launch_live_site
 from scripts.categorize_site import categorize_live_site
 from scripts.check_categories import check_categories
+from scripts.dns_record_handler import generate_hosted_zones
 from scripts.get_data import (
     get_application_list,
     get_domain_list,
@@ -29,6 +30,7 @@ def run():
             s.case("a", get_application_list)
             s.case("s", get_live_site_list)
             s.case("l", launch_live_site)
+            s.case("r", generate_hosted_zones)
             s.case("c", categorize_live_site)
             s.case("e", delete_live_site)
             s.case("h", check_categories)
@@ -46,6 +48,7 @@ View available S3 [W]ebsites
 View available [A]pplications
 View [S]ites that are currently live
 C[H]eck a domain's categorization status
+Create DNS [R]ecord handlers
 [L]aunch a new site
 [C]ategorize an existing site
 Delete an [E]xisting site

--- a/src/setup.py
+++ b/src/setup.py
@@ -1,0 +1,16 @@
+"""Setup tools."""
+# Third-Party Libraries
+from setuptools import setup
+
+setup(
+    name="domain-manager",
+    version="0.1",
+    py_modules=["domain-manager"],
+    install_requires=[
+        "colorama",
+    ],
+    entry_points="""
+        [console_scripts]
+        domain-manager=main:cli
+    """,
+)

--- a/text_files/domains.txt
+++ b/text_files/domains.txt
@@ -1,0 +1,3 @@
+examplesquared.com
+examplecubed.com
+examplepowerthree.com


### PR DESCRIPTION
Add option to create DNS record handlers for newly purchased domains

## 🗣 Description
Interact with the API using the CLI application, you can now quickly create multiple dns record handlers on route53 and retrieve their nameservers

*example:*
drop in a txt file with a list of newly purchased, valid domains

```
example.com
example2.com
example3.com
```

run create dns record handler command

check your `output.txt` file automatically created in the root directory to reterieve nameservers for all your domains

```
example.com

ns1
ns2
ns3
ns4

example2.com

ns1
ns2
ns3
ns4

...
```

## 💭 Motivation and Context
Quickly create DNS record handlers or Route53 Hosted Zones and retrieve all nameservers for a large quantity of newly created domains

## 🧪 Testing
test ran locally and successfully

## 📷 Screenshots (if appropriate)

## 🚥 Types of Changes

<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

<!--- Go over all the following points, and put an `x` in all the
boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask.
We're here to help! -->

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
